### PR TITLE
Add BevAD (CVPR 2026) to Perception-Action Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ If you find this work helpful for your research, please kindly consider citing o
 | `FROST-Drive` | [![arXiv](https://img.shields.io/badge/arXiv-2601.03460-b31b1b?style=flat-square&logo=arxiv)](https://arxiv.org/abs/2601.03460)<br>FROST-Drive: Scalable and Efficient End-to-End Driving with a Frozen Vision Encoder | arXiv 2026 | - | - |
 | `DrivoR` | [![arXiv](https://img.shields.io/badge/arXiv-2601.05083-b31b1b?style=flat-square&logo=arxiv)](https://arxiv.org/abs/2601.05083)<br>Driving on Registers | arXiv 2026 | [![Website](https://img.shields.io/badge/Link-yellow?style=flat-square&logo=gitbook)](https://valeoai.github.io/driving-on-registers/) | [![GitHub](https://img.shields.io/github/stars/valeoai/DrivoR)](https://github.com/valeoai/DrivoR) |
 | `SPS` | [![arXiv](https://img.shields.io/badge/arXiv-2601.10707-b31b1b?style=flat-square&logo=arxiv)](https://arxiv.org/abs/2601.10707)<br>See Less, Drive Better: Generalizable End-to-End Autonomous Driving via Foundation Models Stochastic Patch Selection | arXiv 2026 | - | - |
+| `BevAD` | [![arXiv](https://img.shields.io/badge/arXiv-2603.15185-b31b1b?style=flat-square&logo=arxiv)](https://arxiv.org/abs/2603.15185)<br>What Matters for Scalable and Robust Learning in End-to-End Driving Planners? | CVPR 2026 | [![Website](https://img.shields.io/badge/Link-yellow?style=flat-square&logo=gitbook)](https://dmholtz.github.io/bevad/) | [![GitHub](https://img.shields.io/github/stars/dmholtz/bevad)](https://github.com/dmholtz/bevad) |
 ||
 
 


### PR DESCRIPTION
## Summary

- Adds **BevAD** (arXiv:[2603.15185](https://arxiv.org/abs/2603.15185)) to **Section 1.2 — Perception-Action Models**
- Paper: *What Matters for Scalable and Robust Learning in End-to-End Driving Planners?* — CVPR 2026
- BevAD is a lightweight, scalable end-to-end driving architecture that studies the impact of BEV perceptual representations, disentangled trajectory modeling, and generative planning on closed-loop performance; achieves 72.7% success on Bench2Drive via pure imitation learning
- Includes project page and GitHub links

🤖 Generated with [Claude Code](https://claude.com/claude-code)